### PR TITLE
Add prefix and new Addins

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,8 +30,8 @@ Authors@R:
              role = "ctb",
              email = "patrick.schratz@gmail.com",
              comment = c(ORCID = "0000-0003-0748-6624")))
-Description: It names the 'R Markdown' chunks of files based on
-    the filename.
+Description: It names the 'R Markdown' chunks of files based on the
+    filename.
 License: GPL-3
 URL: https://github.com/lockedata/namer, https://itsalocke.com/namer/
 BugReports: https://github.com/lockedata/namer/issues
@@ -53,4 +53,4 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.1

--- a/R/name_chunks.R
+++ b/R/name_chunks.R
@@ -8,6 +8,7 @@
 #'
 #' @template path
 #' @template unname
+#' @template prefix
 #'
 #' @export
 #'
@@ -21,7 +22,7 @@
 #' file.edit(temp_file_path)
 #' }
 #' file.remove(temp_file_path)
-name_chunks <- function(path, unname = FALSE){
+name_chunks <- function(path, unname = FALSE, prefix){
   # read the whole file
   lines <- readLines(path)
 
@@ -48,13 +49,15 @@ name_chunks <- function(path, unname = FALSE){
 
   # act only if needed!
   if(no_unnamed > 0){
-    # create new chunk names
-    filename <- fs::path_ext_remove(path)
-    filename <- fs::path_file(filename)
+    if (missing(prefix)) {
+      # create new chunk names
+      filename <- fs::path_ext_remove(path)
+      prefix <- fs::path_file(filename)
+    }
     # support for bookdown text references by removing underscores
     # https://bookdown.org/yihui/bookdown/markdown-extensions-by-bookdown.html#fnref5
-    filename <- clean_latex_special_characters(filename)
-    new_chunk_names <-  glue::glue("{filename}-{1:no_unnamed}")
+    prefix <- clean_latex_special_characters(prefix)
+    new_chunk_names <-  glue::glue("{prefix}-{1:no_unnamed}")
     new_chunk_names <- as.character(new_chunk_names)
     # and write to which line they correspond
     names(new_chunk_names) <- unique(unnamed$index)

--- a/R/name_chunks_addin.R
+++ b/R/name_chunks_addin.R
@@ -1,3 +1,17 @@
-name_chunks_addin <- function(){
+name_chunks_file_addin <- function(){
   name_chunks(path = rstudioapi::selectFile(filter = "R Markdown Files (*.Rmd)"))
+}
+
+name_chunks_addin <- function(){
+  prefix <- rstudioapi::showPrompt(title = "Chunk names prefix",
+                                   message = "Leave empty to use filename (Default)", default = "")
+  if (prefix == "") {
+    name_chunks(path = rstudioapi::getActiveDocumentContext()$path)
+  } else {
+    name_chunks(path = rstudioapi::getActiveDocumentContext()$path, prefix = prefix)
+  }
+}
+
+name_chunks_directory_addin <- function(){
+  namer::name_dir_chunks(rstudioapi::selectDirectory())
 }

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,4 +1,14 @@
-Name: Label Rmd Chunks
+Name: Label Current Rmd Chunks
 Description: labels unnamed chunk of the active R Markdown document, based on the filename.
 Binding: name_chunks_addin
+Interactive: false
+
+Name: Label Rmd Chunks from File
+Description: labels unnamed chunk of a chosen R Markdown document, based on the filename.
+Binding: name_chunks_file_addin
+Interactive: true
+
+Name: Label Rmd Chunks from Directory
+Description: labels unnamed chunks of all R Markdown document in a Directory.
+Binding: name_chunks_directory_addin
 Interactive: true

--- a/man-roxygen/prefix.R
+++ b/man-roxygen/prefix.R
@@ -1,0 +1,1 @@
+#' @param prefix prefix to use to name chunks. Default to cleaned name of the Rmd.

--- a/man/name_chunks.Rd
+++ b/man/name_chunks.Rd
@@ -4,7 +4,7 @@
 \alias{name_chunks}
 \title{Name chunks in a single file}
 \usage{
-name_chunks(path, unname = FALSE)
+name_chunks(path, unname = FALSE, prefix)
 }
 \arguments{
 \item{path}{Path to file}
@@ -13,6 +13,8 @@ name_chunks(path, unname = FALSE)
 Turning this option on will cause all existing labels to be overwritten. In
 contrast, with its default `unname = FALSE` only unlabelled chunks will be
 named.}
+
+\item{prefix}{prefix to use to name chunks. Default to cleaned name of the Rmd.}
 }
 \description{
 Name unnamed chunks in a single file using the filename with extension stripped as basis.

--- a/tests/testthat/test-name_chunks.R
+++ b/tests/testthat/test-name_chunks.R
@@ -25,6 +25,18 @@ test_that("renaming works", {
   file.remove(temp_file_path)
 })
 
+test_that("renaming with prefix works", {
+  temp_file_path <- file.path(tmp, "test.Rmd")
+
+  file.copy(system.file("examples", "example1.Rmd", package = "namer"),
+            temp_file_path)
+  name_chunks(temp_file_path, prefix = "my-prefix")
+  lines <- readLines(temp_file_path)
+  chunk_info <- get_chunk_info(lines)
+  expect_true(all(grepl("my-prefix", chunk_info$name[-1])))
+  file.remove(temp_file_path)
+})
+
 test_that("unnaming is advised when needed", {
   temp_file_path <- file.path(tmp, "example4.Rmd")
 


### PR DESCRIPTION
- I think that renaming the current Rmd is still useful in the addins list. So I propose to add it back but in a separate addin from the "select File" one.  
- I added the possibility to define myself the prefix of the chunk name as my very long filenames take too much space in my chunk names. The prefix proposed is pass through the `clean_latex_special_characters()` to be sure everything is good.
- I updated the unit test accordingly
- As I was in the Addins files, I added the "choose a directory" feature.

The 3 addins:
![image](https://user-images.githubusercontent.com/21193866/113577174-24c66100-9621-11eb-962d-84b57477adf3.png)

The interface to choose for "prefix" when using Addin for the "Current Rmd"
![image](https://user-images.githubusercontent.com/21193866/113577338-622aee80-9621-11eb-9bfe-74116bdc39da.png)

